### PR TITLE
Update Docker Publish Workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,10 +6,11 @@ name: Docker
 # documentation.
 
 on:
-  #schedule:
-    #- cron: '31 4 * * *'
+  # schedule:
+    # - cron: '31 4 * * *'
   push:
-    branches: [ "main" ]
+    # branches: [ "main" ]
+    tags: [ 'v*.*.*' ]
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -37,21 +38,21 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 #v3.1.1
+        uses: sigstore/cosign-installer@v3.8.1
         with:
-          cosign-release: 'v2.1.1'
+          cosign-release: 'v2.4.3'
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+        uses: docker/setup-buildx-action@v3
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -61,7 +62,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 


### PR DESCRIPTION
This pull request updates the `.github/workflows/docker-publish.yml` file to modify the workflow trigger conditions and upgrade several GitHub Actions to their latest stable versions for improved maintainability and functionality.

### Workflow trigger updates:
* Changed the workflow trigger from `push` on the `main` branch to `push` on tags matching the pattern `v*.*.*`. This ensures the workflow only runs for versioned releases.

### Dependency updates:
* Upgraded `sigstore/cosign-installer` from `v3.1.1` to `v3.8.1` and `cosign-release` from `v2.1.1` to `v2.4.3` for enhanced security and new features.
* Updated `docker/setup-buildx-action` from a specific commit hash to `v3` for better maintainability.
* Updated `docker/login-action` from a specific commit hash to `v3` for consistency with other dependencies.
* Updated `docker/metadata-action` from a specific commit hash to `v5` for compatibility with the latest Docker metadata features.